### PR TITLE
doc: getting-started: user utilities

### DIFF
--- a/docs/getting-started/prerequisite.md
+++ b/docs/getting-started/prerequisite.md
@@ -168,18 +168,18 @@ correct operation of zoned block devices and to troubleshoot problems.
 
 ### lsblk
 
-The lsblk command in Linux lists block devices, including zoned block devices.
-This utility is generally packaged as part of the *util-linux* package which is
-installed by default on most Linux distributions.
+The `lsblk` command in Linux lists block devices. This includes zoned block
+devices.  This utility is usually included in the *util-linux*
+package, which is installed by default on most Linux distributions.
 
 *lsblk* usage examples are provided [here](../linux/utilities/#lsblk).
 
 ### blkzone
 
-Similarly to the `lsblk` utility, the `blkzone` utility is another program
-generally packaged as part of the *util-linux* package. This utility allows
-listing (reporting) the zones of a zoned block device and to reset the write
-pointer position of a range of zones of the device.
+The `blkzone` utility lists (reports) the zones of a zoned block device and
+makes it possible to reset the write pointer position of a range of zones in
+the device. This utility is usually included in the *util-linux* package, which
+is installed by default on most Linux distributions.
 
 *blkzone* usage examples are provided [here](../projects/util-linux.md#blkzone).
 
@@ -187,42 +187,43 @@ pointer position of a range of zones of the device.
 
 The <a href="http://sg.danny.cz/scsi/lsscsi.html" target="_blank">*lsscsi*</a>
 command lists information about the SCSI devices connected to a Linux system.
-*lsscsi* is generally available as a package with most Linux distributions.
-Refer to your distribution documentation to find out the name of the package
-providing the *lsscsi* utility.
+*lsscsi* is generally available as a package in most Linux distributions.
+Refer to your distribution documentation to find the name of the package
+that provides the *lsscsi* utility.
 
-The [linux utilities](../projects/sg3utils.md#lsscsi) page provides more information
-and usage examples.
+The [linux utilities](../projects/sg3utils.md#lsscsi) page provides more
+information on `lssci` as well as usage examples.
 
 ### sg3_utils
 
-The <a href="http://sg.danny.cz/sg/sg3_utils.html" target="_blank">*sg3_utils*</a>
-package is a collection of command line tools that send SCSI commands to a SCSI
-device.
+The <a href="http://sg.danny.cz/sg/sg3_utils.html"
+target="_blank">*sg3_utils*</a> package is a collection of command line tools
+that send SCSI commands to a SCSI device.
 
-Since in Linux all disks are exposed as SCSI disks, including all ATA drives,
-these utilities can be used to manage both SAS ZBC disks and SATA ZAC disks.
-For SATA disks connected to SATA ports (e.g. An AHCI adapter), the kernel SCSI
-subsystem translates SCSI commands to ATA commands.
+In Linux, all disks are exposed as SCSI disks. This includes ATA drives.
+`sg3_utils` can be used to manage SAS ZBC disks as well as SATA ZAC disks. When
+dealing with SATA disks connected to SATA ports (for example, an AHCI adapter),
+the kernel SCSI subsystem translates SCSI commands into ATA commands.
 
-*sg3_utils* includes three command line tools specific to ZBC disks.
+*sg3_utils* includes three command line tools specific to ZBC disks:
 
 <center>
 
-| Utility Name     | SCSI Command Invoked   | Description                     |
-| :--------------- | :--------------------- | :------------------------------ |
-| **sg_rep_zones** | REPORT ZONES           | Get a ZBC disk zone information |
-| **sg_reset_wp**  | RESET WRITE POINTER    | Reset one or all zones of ZBC disk |
-| **sg_zone**      | CLOSE ZONE, FINISH ZONE, OPEN ZONE | Sends one of these commands to the given ZBC disk |
+| Utility Name     | SCSI Command Invoked   | Description                       |
+| :--------------- | :--------------------- | :-------------------------------- |
+| **sg_rep_zones** | REPORT ZONES           | Get a ZBC disk's zone information |
+| **sg_reset_wp**  | RESET WRITE POINTER    | Reset one zone or all zones on a ZBC disk |
+| **sg_zone**      | CLOSE ZONE, FINISH ZONE, OPEN ZONE | Sends one of these commands to the specified ZBC disk |
 
 </center>
 
-[This section](../projects/sg3utils.md#sg3_utils) shows some examples of these
-utilities execution
+See the sg3_utils section under [SCSI Generic
+Utilites](../projects/sg3utils.md#sg3_utils) for sg3_utils usage examples. 
+
 
 ### libzbc
 
-*libzbc* is a user space library providing functions for manipulating ZBC and
+*libzbc* is a user space library that provides functions for manipulating ZBC and
 ZAC disks.  The *libzbc* project is hosted on
 <a href="https://github.com/westerndigitalcorporation/libzbc" target="_blank">
 GitHub</a>. Documentation is provided in the project
@@ -230,10 +231,11 @@ GitHub</a>. Documentation is provided in the project
 target="_blank"> README</a> file. The API documentation can also be
 automatically generated using *doxygen*.
 
-*libzbc* also provides a set of command line utilities with similar
-functionalities as the `blkzone` utility and *the sg3_utils* command line tools.
+*libzbc* also provides a set of command line utilities that have functions
+similar to the functions of both the `blkzone` utility and *the sg3_utils*
+command line tools.
 
-More information on how to compile and install *libzbc* as well as usage
-examples of the command line utilities provided can be found
-[here](../projects/libzbc.md).
+More information on how to compile and install *libzbc* (as well as usage
+examples of the command line utilities provided) can be found in 
+[the libzbc User Library section of the Applications and Libraries Guide](../projects/libzbc.md).
 


### PR DESCRIPTION
I rewrote the "User Utilites" section of
the Getting Started Guide. This consisted mostly
of removing present participial phrases and
replacing them with relative clauses to reduce
ambiguity and cognitive load on the reader. I
also reworded some sentences so that adjectives
modified nouns a bit less ambiguously.

Signed-off-by: Zac Dover <zac.dover@gmail.com>