### PR TITLE
Doc 2021 08 18 using an sas host bus adapter 1 of x

### DIFF
--- a/docs/getting-started/prerequisite.md
+++ b/docs/getting-started/prerequisite.md
@@ -223,18 +223,19 @@ utilities execution.
 
 ### libzbc
 
-*libzbc* is a user space library providing functions for manipulating ZBC and
-ZAC disks.  The *libzbc* project is hosted on
-<a href="https://github.com/westerndigitalcorporation/libzbc" target="_blank">
-GitHub</a>. Documentation is provided in the project
-<a href="https://github.com/westerndigitalcorporation/libzbc/blob/master/README.md"
-target="_blank"> README</a> file. The API documentation can also be
-automatically generated using *doxygen*.
+*libzbc* is a user-space library that provides functions that are 
+used to manipulate ZBC and ZAC disks.  The *libzbc* project is hosted
+on <a href="https://github.com/westerndigitalcorporation/libzbc"
+target="_blank"> GitHub</a>. Documentation is provided in the project
+<a href="https://github.com/westerndigitalcorporation/libzbc/blob/master/README.md" target="_blank"> README</a> file. The API documentation can be
+generated using *doxygen*.
 
-*libzbc* also provides a set of command line utilities with similar
-functionalities as the `blkzone` utility and *the sg3_utils* command line tools.
+*libzbc* provides a set of command-line utilities that are
+functionally similar to both the `blkzone` utility and *the sg3_utils*
+command-line tools.
 
-More information on how to compile and install *libzbc* as well as usage
-examples of the command line utilities provided can be found
-[here](../projects/libzbc.md).
+For more information on how to compile and install *libzbc*, as well as usage
+examples of the command line utilities provided by *libzbc*, see [libzbc User
+Library](../projects/libzbc.md) in the Zoned Storage Applications and Libraries
+documentation.
 

--- a/docs/getting-started/smr-disk.md
+++ b/docs/getting-started/smr-disk.md
@@ -201,52 +201,52 @@ Zone 55878: type 0x2 (Sequential-write-required), cond 0x1 (Empty), reset recomm
 Zone 55879: type 0x2 (Sequential-write-required), cond 0x1 (Empty), reset recommended 0, non_seq 0, sector 29296689152, 524288 sectors, wp 29296689152
 ```
 
-## Using a SAS Host Bus Adapter
+## Using an SAS Host Bus Adapter
 
-AHCI adapters can only accomodate Serial ATA disks and generally only provide a
+AHCI adapters can accomodate only Serial ATA disks and provide only a
 limited number of ports. SAS Host Bus Adapters (HBA) are widely used in
 enterprise applications to overcome AHCI limitations. The SAS transport layer
-used by SAS HBAs can equally accomodate both Serial ATA and SCSI disks.
+that is used by SAS HBAs can accomodate Serial ATA and SCSI disks equally.
 
 ### HBA Compatibility
 
-While most AHCI adapters for Serial ATA disks generally do not cause any
-problem with host managed ZAC disks identification, SAS HBAs on the other
-hand may suffer from a lack of support depending on the HBA model being used.
+Most AHCI adapters for Serial ATA disks do not cause any problem with the
+identification of host managed ZAC disks, but SAS HBAs may not be supported 
+(depending on the HBA model being used).
 
-The compatibility of a SAS HBA with host managed disks mainly depends on
+The compatibility of an SAS HBA with host managed disks depends mainly on
 the following factors.
 
 1. The HBA must have the ability to recognize the host managed device type
    *0x14* of host managed SAS disks (ZBC/SCSI).
 
-2. The HBA must have the ability to recognize the host managed device signature 
-   *0xabcd* of SATA host managed ZAC disks and translate this signature into
-   the ZBC defined SCSI device type *0x14*.
+2. The HBA must have the ability to recognize the host managed device signature
+   *0xabcd* of SATA host managed ZAC disks and the ability to translate this
+   signature into the ZBC defined SCSI device type *0x14*.
 
 3. Generalizing the previous point, the HBA must implement a SCSI-to-ATA
-   translation (SAT) layer supporting the conversion of host issued ZBC zone
+   translation (SAT) layer that supports the conversion of host issued ZBC zone
    commands into ZAC zone commands that can be executed by a SATA ZAC disk
-   connected to the HBA.
+   that is connected to the HBA.
 
-Any HBA failing the first requirement will not expose a ZBC host managed disk to
-the host. Similarly, an HBA failing to comply with the second and third
-requirement will fail to expose to the host a host managed ZAC disk as a ZBC
-host managed disk.
+Any HBA that fails the first requirement will not expose a ZBC host managed
+disk to the host. Similarly, an HBA that fails to comply with the second and
+third requirements will fail to expose to the host a host-managed ZAC disk as a
+ZBC host-managed disk.
 
 In the case of a host aware disk model, the device type and device signature
-handling will not cause any problem (recall that host aware disks use the
-regular disk device type and signatur *0x00*). Host aware disks will thus always
-be useable as regular disks with any HBA. The execution of ZBC zone commands
-with a SAS host aware disk may also work most of the time. However, similarly
-to host managed disk, the absence of a ZBC/ZAC compatible SAT layer will prevent
-the use of a Serial ATA host aware disk as a ZBC host aware disk. The ZBC zone
-commands sent to the SATA disk will not be translated and result in command
-failures.
+handling will not cause any problem (remember that host aware disks use the
+regular disk device type and signature *0x00*). Host aware disks will thus
+always be usable as regular disks with any HBA. ZBC zone commands should
+usually be executable on SAS host aware disks. However (similar to the behavior
+of host managed disks), the absence of a ZBC/ZAC compatible SAT layer prevents
+the use of a Serial ATA host aware disk as a ZBC host aware disk. Any ZBC zone
+commands that are sent to the SATA disk will not be translated and therefore
+will result in command failures.
 
 The compatibility of an HBA model with the ZBC and ZAC standards should be
-checked with the HBA vendor. Under some conditions, an HBA compatibility can
-also be checked using the [*libzbc* conformance test suite](/tests/zbc-tests).
+checked with the HBA vendor. Under some conditions, HBA compatibility can
+be checked using the [*libzbc* conformance test suite](/tests/zbc-tests).
 
 ### Verifying The Disk
 


### PR DESCRIPTION
doc: smr-disk: Using SAS HBA & HBA Compat

This PR rewrites the top matter in the section
"Using a [sic] SAS Host Bus Adapter" (this is
one of the several things changed in this PR).

This PR also rewrites the "HBA Compatibility"
subsection under the above-mentioned section.

Signed-off-by: Zac Dover <zac.dover@gmail.com>