### PR TITLE
fix: Allow scrolling in ToC sidebar

### DIFF
--- a/cinder/css/cinder.css
+++ b/cinder/css/cinder.css
@@ -63,6 +63,17 @@ pre {
     font-family: Inter,"Helvetica Neue",Helvetica,Arial,sans-serif;
     font-size: 13px;
 }
+
+.bs-sidebar {
+    overflow-y: scroll;
+    -ms-overflow-style: none;  /* IE and Edge */
+    scrollbar-width: none;  /* Firefox */
+}
+
+.bs-sidebar::-webkit-scrollbar {
+    display: none; /* Chrome, Safari */
+}
+
 .well {
     background-color: #FCFDFF;
 }


### PR DESCRIPTION
If the sidebar toc does not fit on screen (/linux/dm on 1080p), the bottom of the toc cannot be used
in Firefox and Chrome (did not test others). This patch allows the sidebar to be scrolled.

Signed-off-by: Andreas Hindborg <andreas.hindborg@wdc.com>