### PR TITLE
linux.md: Added Debian 11 (Bullseye)

### DIFF
--- a/docs/distributions/linux.md
+++ b/docs/distributions/linux.md
@@ -56,6 +56,8 @@ for the most recent distribution releases.
 | -------------------- | -------------- | ----------- | ------------------ | ----------- |
 | 9 (Stretch) |	4.9 | <span style="color:red">No</span> | <span style="color:red">No</span> | <span style="color:red">No</span> |
 | 10 (Buster) |	4.19 |  <span style="color:green">Yes</span> | <span style="color:green">Yes</span> | <span style="color:red">No</span> |
+| 11 (Bullseye) | 5.10 |  <span style="color:green">Yes</span> | <span style="color:green">Yes</span> | <span style="color:green">Yes</span> |
+
 
 </center>
 


### PR DESCRIPTION
Added Debian 11 (Bullseye), which provides full support for all of the necessary features (ZBD support, dm-zoned support, ZNS
support)

Signed-off-by: Lenz Grimmer <lenz.grimmer@percona.com>