### PR TITLE
doc/tools: fix mis-formatted targetcli commad line

### DIFF
--- a/docs/tools/tcmu-runner.md
+++ b/docs/tools/tcmu-runner.md
@@ -122,7 +122,7 @@ Copyright 2011-2013 by Datera, Inc and others.
 For help on commands, type 'help'.
 
 /> cd /backstores/user:zbc
-/backstores/user:zbc> {==create name=zbc0 size=20G cfgstring=model-HM/zsize-256/conv-10@/var/local/zbc0.raw==}
+/backstores/user:zbc> create name=zbc0 size=20G cfgstring=model-HM/zsize-256/conv-10@/var/local/zbc0.raw
 Created user-backed storage object zbc0 size 21474836480.
 /backstores/user:zbc> cd /loopback
 /loopback> create


### PR DESCRIPTION
The commad line of targetcli example contains invalid format strings
"{==" and "==}". Drop them to fix the commad.
