### PR TITLE
doc/getting-started: add null_blk tutorial

### DIFF
--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -7,7 +7,28 @@ slug: /getting-started
 
 # Getting Started
 
+## Overview
+
 Learn how to set up a Linux system to use zoned storage devices.
+
+## Introduction
+
+If you have never used a zoned block device before, this is the chapter that
+you should read. 
+
+## null_blk Emulation Setup
+
+The following three-step procedure results in an environment that will allow
+you to evaluate ZonedStorage and to investigate its features. This is the
+fastest way to get started, and is recommended for first-time readers.
+
+This procedure creates a zoned null block device. It is okay if you do not yet
+know what that means. This is the simplest way to try out ZonedStorage.
+
+1. Install a Linux distribution that supports ZonedStorage. Fedora 36 is recommended.
+1. [Create a zoned null_blk device](./nullblk.md#creating-a-zoned-null-block-device--simplest-case). "null_blk" is pronounced "null block", and for our purposes in this tutorial, you need to know only that the "null block device" emulates a block device.
+
+# Reference Section
 
 * [Linux Distributions](../distributions/linux.md): Learn about the support
   provided by the pre-compiled binary kernels shipped with various Linux


### PR DESCRIPTION
This PR adds a tutorial that will guide first-time
readers to create a zoned null block device.

This is the simplest of the three scenarios that
we will add to the guide. The other two, in order
of increasing complexity, are (1) emulated devices
(either qemu ZNS or scsi tcmu-runner) and (2) real
hardware.

This is part of an initiative to reorganize the Getting
Started page so that it turns beginners into adepts as
quickly as possible.

Signed-off-by: Zac Dover <zac.dover@gmail.com>