### PR TITLE
xfs: add minor section for Zonar

### DIFF
--- a/docs/filesystems/xfs.md
+++ b/docs/filesystems/xfs.md
@@ -315,3 +315,10 @@ kernel.org</a>. See the <a
 href="https://git.kernel.org/pub/scm/fs/xfs/xfsprogs-dev.git/tree/doc/INSTALL"
 target="_blank">INSTALL</a> file for instructions on how to compile and install
 this package.
+
+## Monitoring Zoned XFS with [Zonar](/docs/applications/zonar)
+
+Zonar is a graphical user-interface (GUI) application that allows users to
+monitor and visualise a zoned filesystem in realtime. Zonar supports zoned XFS
+on both zoned and regular devices. See [here](/docs/applications/zonar) to
+learn more about zonar and how to utilize it for monitoring zoned XFS.


### PR DESCRIPTION
Append a small note about Zonar to the XFS page. Zonar can be used for monitoring and debugging Zoned XFS, as such, it is a good idea for users to be aware fo this tool.