### PR TITLE
linux/overview: Resolve contradiction about URSWRZ

### DIFF
--- a/docs/linux/overview.md
+++ b/docs/linux/overview.md
@@ -234,9 +234,9 @@ Linux.
   sectors that are after the write-pointer position of a zone.) Linux supports
   only ZBC and ZAC host-managed hard disks that allow unrestricted read
   commands. In other words, Linux supports only SMR hard disks that report that
-  the *URSWRZ* bit is not set. This restriction has been added to ensure that
-  the block-layer disk-partition-scanning process does not result in read
-  commands that fail whenever the disk partition table is checked.
+  the *URSWRZ* bit is set. This restriction has been added to ensure that the
+  block-layer disk-partition-scanning process does not result in read commands
+  that fail whenever the disk partition table is checked.
 
 * **Direct IO Writes** The kernel page cache does not guarantee that cached
   dirty pages will be flushed to a block device in sequential sector order.


### PR DESCRIPTION
As of Linux 7.2, Host Managed drives that do *not* have the URSWRZ bits
set are not supported. [1] Other operating systems like FreeBSD also
interpret the URSWRZ bit as set for indicating its support. [2]

[1] https://github.com/torvalds/linux/blob/a13c140cc289c0b7b3770bce5b3ad42ab35074aa/drivers/scsi/sd_zbc.c#L440-L450
[2] https://github.com/freebsd/freebsd-src/blob/67f1c082b5ec37e2060b74e6f1f952ed38761468/sys/cam/scsi/scsi_da.c#L3326-L3327
